### PR TITLE
remove tayga and awalwm2m packages from creator-kit.config

### DIFF
--- a/creator-kit.config
+++ b/creator-kit.config
@@ -4,5 +4,3 @@ CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_PACKAGE_button-gateway=y
 CONFIG_PACKAGE_device-manager=y
 CONFIG_PACKAGE_webscripts=y
-CONFIG_PACKAGE_awalwm2m=y
-CONFIG_PACKAGE_tayga=y


### PR DESCRIPTION
button-gateway is dependent on awalwm2m, hence it is not required
to be enabled from creator-kit.config. Similarly, device-manager
is dependent on tayga.