### PR TITLE
add build version details in openwrt image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,11 @@ openwrt/.config: openwrt/feeds.conf
 	cat creator-kit.config > ../dist/openwrt/.config
 	$(MAKE) -C ../dist/openwrt defconfig
 
+openwrt/version:
+	./getver.sh ../dist/openwrt > ../dist/openwrt/version
+
 .PHONY: build_openwrt
-build_openwrt: openwrt/.config
+build_openwrt: openwrt/.config openwrt/version
 	if test $(findstring J=,$(MAKEFLAGS)); then \
 		$(MAKE) $(SUBMAKEFLAGS) -C ../dist/openwrt -j$(J); \
 	else \

--- a/creator-kit.config
+++ b/creator-kit.config
@@ -4,3 +4,6 @@ CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_PACKAGE_button-gateway=y
 CONFIG_PACKAGE_device-manager=y
 CONFIG_PACKAGE_webscripts=y
+CONFIG_IMAGEOPT=y
+CONFIG_VERSIONOPT=y
+CONFIG_VERSION_NUMBER="v0.9.0"

--- a/getver.sh
+++ b/getver.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+export LANG=C
+export LC_ALL=C
+[ -n $1 ] && cd $1
+
+try_git() {
+	[ -e .git ] || return 1
+	REV="$(git log | grep -m 1 commit | awk '{print substr ($2, 0, 7)}')"
+	[ -n "$REV" ]
+}
+
+try_git || REV="unknown"
+echo "$REV"


### PR DESCRIPTION
Versioning details have been added at two places :-
- DISTRIB_RELEASE: which shows the release or tag version of creatorkit
  builds e.g. v0.9.0
- DISTRIB_REVISION: which shows the latest git revision of openwrt repository.