### PR TITLE
Remove webscripts from all creator project configs

### DIFF
--- a/creator-kit-1-cascoda.config
+++ b/creator-kit-1-cascoda.config
@@ -2,7 +2,6 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
 CONFIG_PACKAGE_button-led-controller=y
-CONFIG_PACKAGE_webscripts=y
 CONFIG_IMAGEOPT=y
 CONFIG_LOCALMIRROR="http://downloads.creatordev.io/pistachio/marduk/dl"
 CONFIG_VERSIONOPT=y

--- a/creator-kit-1.config
+++ b/creator-kit-1.config
@@ -2,7 +2,6 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_PACKAGE_button-led-controller=y
-CONFIG_PACKAGE_webscripts=y
 CONFIG_IMAGEOPT=y
 CONFIG_LOCALMIRROR="http://downloads.creatordev.io/pistachio/marduk/dl"
 CONFIG_VERSIONOPT=y

--- a/creator-kit-2-cascoda.config
+++ b/creator-kit-2-cascoda.config
@@ -2,7 +2,6 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
 CONFIG_PACKAGE_motion-led-controller=y
-CONFIG_PACKAGE_webscripts=y
 CONFIG_IMAGEOPT=y
 CONFIG_LOCALMIRROR="http://downloads.creatordev.io/pistachio/marduk/dl"
 CONFIG_VERSIONOPT=y

--- a/creator-kit-2.config
+++ b/creator-kit-2.config
@@ -2,7 +2,6 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_PACKAGE_motion-led-controller=y
-CONFIG_PACKAGE_webscripts=y
 CONFIG_IMAGEOPT=y
 CONFIG_LOCALMIRROR="http://downloads.creatordev.io/pistachio/marduk/dl"
 CONFIG_VERSIONOPT=y

--- a/creator-kit-3-cascoda.config
+++ b/creator-kit-3-cascoda.config
@@ -2,7 +2,6 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
 CONFIG_PACKAGE_relay-gateway=y
-CONFIG_PACKAGE_webscripts=y
 CONFIG_IMAGEOPT=y
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"

--- a/creator-kit-3.config
+++ b/creator-kit-3.config
@@ -2,7 +2,6 @@ CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_PACKAGE_relay-gateway=y
-CONFIG_PACKAGE_webscripts=y
 CONFIG_IMAGEOPT=y
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"

--- a/creator-platform-all-cascoda.config
+++ b/creator-platform-all-cascoda.config
@@ -1,7 +1,6 @@
 CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
-CONFIG_PACKAGE_webscripts=y
 CONFIG_PACKAGE_uboot-pistachio_marduk=y
 CONFIG_ALL=y
 CONFIG_IB=y

--- a/creator-platform-all.config
+++ b/creator-platform-all.config
@@ -1,7 +1,6 @@
 CONFIG_TARGET_pistachio=y
 CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
-CONFIG_PACKAGE_webscripts=y
 CONFIG_PACKAGE_uboot-pistachio_marduk=y
 CONFIG_ALL=y
 CONFIG_IB=y


### PR DESCRIPTION
Since luci has been added into default openwrt packages which installs
index.html at /www/ where webscripts also installs the index.html.
so to avoid conflict remove webscripts from package list.

Signed-off-by: Abhijit Mahajani <Abhijit.Mahajani@imgtec.com>