### PR TITLE
Add channel, pan_id and option to use serial pads for contiki build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 J?=1
+CH?=26
+ID?=0xabcd
+SER?=0
 DIR__BUILD:=$(PWD)
 DIR__CKT:=$(DIR__BUILD)/..
 DIR__OPENWRT:=$(DIR__BUILD)/../dist/openwrt
@@ -57,11 +60,11 @@ get_kit_app:
 build_contiki: get_kit_app
 ifneq (_,_$(findstring cascoda,$P))
 	@cd $(DIR__CONTIKI);git submodule init dev/ca8210;git submodule update
-	@if [ $(KIT_APP_NO) -eq "1" ]; then $(MAKE) -C $(DIR__CKT)/packages/button-sensor TARGET=mikro-e USE_CA8210=1; fi
-	@if [ $(KIT_APP_NO) -eq "2" ]; then $(MAKE) -C $(DIR__CKT)/packages/motion-sensor TARGET=mikro-e USE_CA8210=1; fi
+	@if [ $(KIT_APP_NO) -eq "1" ]; then $(MAKE) -C $(DIR__CKT)/packages/button-sensor TARGET=mikro-e USE_CA8210=1 USE_SERIAL_PADS=$(SER) CHANNEL=$(CH) PAN_ID=$(ID); fi
+	@if [ $(KIT_APP_NO) -eq "2" ]; then $(MAKE) -C $(DIR__CKT)/packages/motion-sensor TARGET=mikro-e USE_CA8210=1 USE_SERIAL_PADS=$(SER) CHANNEL=$(CH) PAN_ID=$(ID); fi
 else
-	@if [ $(KIT_APP_NO) -eq "1" ]; then $(MAKE) -C $(DIR__CKT)/packages/button-sensor TARGET=mikro-e USE_CC2520=1; fi
-	@if [ $(KIT_APP_NO) -eq "2" ]; then $(MAKE) -C $(DIR__CKT)/packages/motion-sensor TARGET=mikro-e USE_CC2520=1; fi
+	@if [ $(KIT_APP_NO) -eq "1" ]; then $(MAKE) -C $(DIR__CKT)/packages/button-sensor TARGET=mikro-e USE_CC2520=1 USE_SERIAL_PADS=$(SER) CHANNEL=$(CH) PAN_ID=$(ID); fi
+	@if [ $(KIT_APP_NO) -eq "2" ]; then $(MAKE) -C $(DIR__CKT)/packages/motion-sensor TARGET=mikro-e USE_CC2520=1 USE_SERIAL_PADS=$(SER) CHANNEL=$(CH) PAN_ID=$(ID); fi
 endif
 
 # Copy files to build/output/

--- a/README.md
+++ b/README.md
@@ -121,3 +121,17 @@ For CA8210:
 For CC2520:
 
     $ make openwrt P=creator-platform-all.config V=s
+
+
+## Contiki specific build options:
+
+Contiki
+
+    $ make contiki P=creator-kit-1-cascoda.config SER=1 CH=26 ID=0xabcd
+
+
+Here SER means USE_SERIAL_PADS i.e. UART2 for serial console
+You can pass channel number in CH and pan_id in ID option.
+Default values of CH , ID, SER are 26, 0xabcd, 0 respectively.
+
+


### PR DESCRIPTION
Update build makefile to pass 6lowpan channel and pan id and option to use serial pads for contiki.
Also update readme accordingly. 
e.g. make contiki P=creator-kit-x.config CH=26 ID=0xabcd SER=1 