### PR TITLE
opkg: Enable ssl support to download package list

### DIFF
--- a/creator-kit-1-cascoda.config
+++ b/creator-kit-1-cascoda.config
@@ -3,12 +3,20 @@ CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
 CONFIG_PACKAGE_button-led-controller=y
 CONFIG_IMAGEOPT=y
-CONFIG_LOCALMIRROR="http://downloads.creatordev.io/pistachio/marduk/dl"
+CONFIG_LOCALMIRROR="https://downloads.creatordev.io/pistachio/marduk/dl"
+CONFIG_OPENSSL_WITH_EC=y
+CONFIG_PACKAGE_ca-certificates=y
+CONFIG_PACKAGE_libopenssl=y
+CONFIG_PACKAGE_libustream-openssl=y
+CONFIG_PACKAGE_opkg-smime=y
+# CONFIG_PACKAGE_usign is not set
+CONFIG_PACKAGE_zlib=y
+# CONFIG_SIGNED_PACKAGES is not set
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"
 CONFIG_VERSION_NICK="Ci40Kit1Project1"
 CONFIG_VERSION_NUMBER="dev"
-CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"
+CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"
 CONFIG_VERSION_PRODUCT="Creator Ci40(Marduk)"

--- a/creator-kit-1.config
+++ b/creator-kit-1.config
@@ -3,12 +3,20 @@ CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_PACKAGE_button-led-controller=y
 CONFIG_IMAGEOPT=y
-CONFIG_LOCALMIRROR="http://downloads.creatordev.io/pistachio/marduk/dl"
+CONFIG_LOCALMIRROR="https://downloads.creatordev.io/pistachio/marduk/dl"
+CONFIG_OPENSSL_WITH_EC=y
+CONFIG_PACKAGE_ca-certificates=y
+CONFIG_PACKAGE_libopenssl=y
+CONFIG_PACKAGE_libustream-openssl=y
+CONFIG_PACKAGE_opkg-smime=y
+# CONFIG_PACKAGE_usign is not set
+CONFIG_PACKAGE_zlib=y
+# CONFIG_SIGNED_PACKAGES is not set
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"
 CONFIG_VERSION_NICK="Ci40Kit1Project1"
 CONFIG_VERSION_NUMBER="dev"
-CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"
+CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"
 CONFIG_VERSION_PRODUCT="Creator Ci40(Marduk)"

--- a/creator-kit-2-cascoda.config
+++ b/creator-kit-2-cascoda.config
@@ -3,12 +3,20 @@ CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
 CONFIG_PACKAGE_motion-led-controller=y
 CONFIG_IMAGEOPT=y
-CONFIG_LOCALMIRROR="http://downloads.creatordev.io/pistachio/marduk/dl"
+CONFIG_LOCALMIRROR="https://downloads.creatordev.io/pistachio/marduk/dl"
+CONFIG_OPENSSL_WITH_EC=y
+CONFIG_PACKAGE_ca-certificates=y
+CONFIG_PACKAGE_libopenssl=y
+CONFIG_PACKAGE_libustream-openssl=y
+CONFIG_PACKAGE_opkg-smime=y
+# CONFIG_PACKAGE_usign is not set
+CONFIG_PACKAGE_zlib=y
+# CONFIG_SIGNED_PACKAGES is not set
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"
 CONFIG_VERSION_NICK="Ci40Kit1Project2"
 CONFIG_VERSION_NUMBER="dev"
-CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"
+CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"
 CONFIG_VERSION_PRODUCT="Creator Ci40(Marduk)"

--- a/creator-kit-2.config
+++ b/creator-kit-2.config
@@ -3,12 +3,20 @@ CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_PACKAGE_motion-led-controller=y
 CONFIG_IMAGEOPT=y
-CONFIG_LOCALMIRROR="http://downloads.creatordev.io/pistachio/marduk/dl"
+CONFIG_LOCALMIRROR="https://downloads.creatordev.io/pistachio/marduk/dl"
+CONFIG_OPENSSL_WITH_EC=y
+CONFIG_PACKAGE_ca-certificates=y
+CONFIG_PACKAGE_libopenssl=y
+CONFIG_PACKAGE_libustream-openssl=y
+CONFIG_PACKAGE_opkg-smime=y
+# CONFIG_PACKAGE_usign is not set
+CONFIG_PACKAGE_zlib=y
+# CONFIG_SIGNED_PACKAGES is not set
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"
 CONFIG_VERSION_NICK="Ci40Kit1Project2"
 CONFIG_VERSION_NUMBER="dev"
-CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"
+CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"
 CONFIG_VERSION_PRODUCT="Creator Ci40(Marduk)"

--- a/creator-kit-3-cascoda.config
+++ b/creator-kit-3-cascoda.config
@@ -3,11 +3,19 @@ CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_ca8210=y
 CONFIG_PACKAGE_relay-gateway=y
 CONFIG_IMAGEOPT=y
+CONFIG_OPENSSL_WITH_EC=y
+CONFIG_PACKAGE_ca-certificates=y
+CONFIG_PACKAGE_libopenssl=y
+CONFIG_PACKAGE_libustream-openssl=y
+CONFIG_PACKAGE_opkg-smime=y
+# CONFIG_PACKAGE_usign is not set
+CONFIG_PACKAGE_zlib=y
+# CONFIG_SIGNED_PACKAGES is not set
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"
 CONFIG_VERSION_NICK="Ci40Kit1Project3"
 CONFIG_VERSION_NUMBER="dev"
-CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"
+CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"
 CONFIG_VERSION_PRODUCT="Creator Ci40(Marduk)"

--- a/creator-kit-3.config
+++ b/creator-kit-3.config
@@ -3,11 +3,19 @@ CONFIG_TARGET_pistachio_marduk=y
 CONFIG_TARGET_pistachio_marduk_marduk_cc2520=y
 CONFIG_PACKAGE_relay-gateway=y
 CONFIG_IMAGEOPT=y
+CONFIG_OPENSSL_WITH_EC=y
+CONFIG_PACKAGE_ca-certificates=y
+CONFIG_PACKAGE_libopenssl=y
+CONFIG_PACKAGE_libustream-openssl=y
+CONFIG_PACKAGE_opkg-smime=y
+# CONFIG_PACKAGE_usign is not set
+CONFIG_PACKAGE_zlib=y
+# CONFIG_SIGNED_PACKAGES is not set
 CONFIG_VERSIONOPT=y
 CONFIG_VERSION_DIST="OpenWrt"
 CONFIG_VERSION_NICK="Ci40Kit1Project3"
 CONFIG_VERSION_NUMBER="dev"
-CONFIG_VERSION_REPO="http://downloads.creatordev.io/pistachio/marduk/packages"
+CONFIG_VERSION_REPO="https://downloads.creatordev.io/pistachio/marduk/packages"
 CONFIG_VERSION_MANUFACTURER="Imagination Technologies"
 CONFIG_VERSION_MANUFACTURER_URL="www.imgtec.com"
 CONFIG_VERSION_PRODUCT="Creator Ci40(Marduk)"


### PR DESCRIPTION
1. Enable libustream-ssl require for uclient-fetch
2. Enable ca-certificates to install certificates of CA to target
3. Disbaled package signing option, as it is no longer required

Signed-off-by: Avinash Tahakik <avinashtahakik@gmail.com>